### PR TITLE
Use short life Activity context for GUI parts

### DIFF
--- a/Utilities/src/main/java/com/sentaroh/android/Utilities/Dialog/CommonFileSelector.java
+++ b/Utilities/src/main/java/com/sentaroh/android/Utilities/Dialog/CommonFileSelector.java
@@ -428,7 +428,7 @@ public class CommonFileSelector extends DialogFragment {
 
 
         final Activity activity=getActivity();
-        final Context context=activity.getApplicationContext();
+        final Context context=this.getActivity();
 
         if (mDialogEnableCreate) {
             btnCreate.setVisibility(TextView.VISIBLE);

--- a/Utilities/src/main/java/com/sentaroh/android/Utilities/Dialog/FileSelectDialogFragment.java
+++ b/Utilities/src/main/java/com/sentaroh/android/Utilities/Dialog/FileSelectDialogFragment.java
@@ -516,7 +516,7 @@ public class FileSelectDialogFragment extends DialogFragment {
 		
 		
 		final Activity activity=getActivity();
-		final Context context=activity.getApplicationContext();
+		final Context context=this.getActivity();
 	
 		if (mDialogEnableCreate) {
 			btnCreate.setVisibility(TextView.VISIBLE);

--- a/Utilities/src/main/java/com/sentaroh/android/Utilities/LogUtil/CommonLogFileListDialogFragment.java
+++ b/Utilities/src/main/java/com/sentaroh/android/Utilities/LogUtil/CommonLogFileListDialogFragment.java
@@ -192,7 +192,7 @@ public class CommonLogFileListDialogFragment extends DialogFragment{
     	mFragment=this;
         if (!mTerminateRequired) {
 //            mGp=(CommonGlobalParms)getActivity().getApplication();
-            mContext=getActivity().getApplicationContext();
+            mContext=this.getActivity();
             Bundle bd=getArguments();
             setRetainInstance(bd.getBoolean("retainInstance"));
             mDialogTitle=bd.getString("title");


### PR DESCRIPTION
This is the proper use for Activity context (UI), also needed to theme and change language of GUI parts
Avoids using global getApplicationContext() for short living UI activities